### PR TITLE
Move Edit State to Provider

### DIFF
--- a/lib/controllers/api_implementation.dart
+++ b/lib/controllers/api_implementation.dart
@@ -10,7 +10,7 @@ class UserApi extends Api {
 
   @override
   Future<User> getUser(final String url) async {
-    late User user;
+
     try {
       final response = await http.get(Uri.parse(baseUrl + url));
 
@@ -18,7 +18,7 @@ class UserApi extends Api {
         final String rawJson = response.body;
         final jsonMap = jsonDecode(rawJson)[0];
 
-        user = User(
+        return User(
             userId: jsonMap['id'].toString(),
             email: jsonMap['email'].toString(),
             firstName: jsonMap['name'].toString().split(' ')[0],
@@ -37,7 +37,8 @@ class UserApi extends Api {
       throw '$e';
     }
 
-    return user;
+    return User(userId: '', email: '', firstName: '', lastName: '',
+        zip: '', address: '', city: '', state: '', phone: '');
   }
 
 

--- a/lib/controllers/api_implementation.dart
+++ b/lib/controllers/api_implementation.dart
@@ -10,6 +10,7 @@ class UserApi extends Api {
 
   @override
   Future<User> getUser(final String url) async {
+    late User user;
 
     try {
       final response = await http.get(Uri.parse(baseUrl + url));
@@ -18,7 +19,7 @@ class UserApi extends Api {
         final String rawJson = response.body;
         final jsonMap = jsonDecode(rawJson)[0];
 
-        return User(
+        user = User(
             userId: jsonMap['id'].toString(),
             email: jsonMap['email'].toString(),
             firstName: jsonMap['name'].toString().split(' ')[0],
@@ -37,8 +38,7 @@ class UserApi extends Api {
       throw '$e';
     }
 
-    return User(userId: '', email: '', firstName: '', lastName: '',
-        zip: '', address: '', city: '', state: '', phone: '');
+    return user;
   }
 
 

--- a/lib/controllers/user_provider.dart
+++ b/lib/controllers/user_provider.dart
@@ -5,11 +5,19 @@ import 'api_implementation.dart';
 
 class UserProvider with ChangeNotifier {
   User? _user;
+  bool _isEditing = false;
 
   Future<void> fetchUser() async {
     _user = await UserApi().getUser('');
     notifyListeners();
   }
 
+  void toggleEditing() {
+    _isEditing = !_isEditing;
+    notifyListeners();
+  }
+
   User? get user => _user;
+
+  bool get isEditing => _isEditing;
 }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -20,16 +20,11 @@ final angelenoAccountButtonStyle =  ButtonStyle(
 
 final actionButtonStyle = ElevatedButton.styleFrom(
     backgroundColor: colorGreen,
-    disabledBackgroundColor: Colors.transparent,
+    disabledBackgroundColor: const Color(0xFF81d3a8),
+    disabledForegroundColor: Colors.white,
     alignment: Alignment.center,
     textStyle: const TextStyle(
-        color: Colors.black
+        color: Colors.white
     ),
-    surfaceTintColor: Colors.transparent,
     foregroundColor: Colors.white,
-    shadowColor: Colors.transparent,
-    // shape: const RoundedRectangleBorder(
-    //     borderRadius: BorderRadius.all(Radius.circular(4.0)),
-    //     side: BorderSide()
-    // )
 );

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -39,8 +39,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(final BuildContext context) {
     final bool smallScreen = MediaQuery.of(context).size.width < 720;
-    print('Rebuilding');
-    
+
     return Container(
       margin: const EdgeInsets.fromLTRB(0, 47.0, 0, 0),
       child: Scaffold(

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -102,11 +102,12 @@ class _MyHomePageState extends State<MyHomePage> {
               : Container(
                   color: footerBlue,
                   padding: const EdgeInsets.all(16.0),
-                  child: const Wrap(
+                  child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           Text(
                             '© Copyright 2023 City of Los Angeles. '
-                                'All rights reserved. Disclaimer | Privacy Policy',
+                            'All rights reserved. Disclaimer | Privacy Policy',
                             style: TextStyle(color: Colors.white),
                             textDirection: TextDirection.ltr,
                           )

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -3,6 +3,9 @@ import 'package:angeleno_project/views/nav/app_bar.dart';
 import 'package:angeleno_project/views/screens/password_screen.dart';
 import 'package:angeleno_project/views/screens/profile_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../controllers/user_provider.dart';
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key});
@@ -12,6 +15,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  late UserProvider userProvider;
   int _selectedIndex = 0;
 
   @override
@@ -19,10 +23,49 @@ class _MyHomePageState extends State<MyHomePage> {
     super.initState();
   }
 
+  Future<void> _unsavedDataDialog(final int futureIndex) async =>
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (final BuildContext context) => AlertDialog(
+        title: const Text('You have unsaved changes'),
+        content: const SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Text('Your changes have not been saved. Discard changes?')
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          TextButton(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop();
+              userProvider.toggleEditing();
+              setState(() {
+                _selectedIndex = futureIndex;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+
   void _navigationSelected(final int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+
+    if (userProvider.isEditing && index != 0) {
+      _unsavedDataDialog(index);
+    } else {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
   }
 
   List<Widget> get screens => <Widget>[
@@ -37,6 +80,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(final BuildContext context) {
     final bool smallScreen = MediaQuery.of(context).size.width < 720;
+     userProvider = context.watch<UserProvider>();
 
     return Container(
       margin: const EdgeInsets.fromLTRB(0, 47.0, 0, 0),

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -102,8 +102,8 @@ class _MyHomePageState extends State<MyHomePage> {
               : Container(
                   color: footerBlue,
                   padding: const EdgeInsets.all(16.0),
-                  child: const Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
+                  child: const Wrap(
+                        alignment: WrapAlignment.center,
                         children: [
                           Text(
                             '© Copyright 2023 City of Los Angeles. '

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -26,15 +26,13 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   List<Widget> get screens => <Widget>[
-    const ProfileScreen(),
-    const PasswordScreen(),
-    //Security
-    ListView(
-      children: const [
-        Text('This looks like an external script.')
-      ],
-    )
-  ];
+        const ProfileScreen(),
+        const PasswordScreen(),
+        //Security
+        ListView(
+          children: const [Text('This looks like an external script.')],
+        )
+      ];
 
   @override
   Widget build(final BuildContext context) {
@@ -45,90 +43,76 @@ class _MyHomePageState extends State<MyHomePage> {
       child: Scaffold(
           appBar: const MainAppBar(),
           body: Container(
-          transformAlignment: Alignment.center,
-          /*
+              transformAlignment: Alignment.center,
+              /*
           **  Add constraints when we figure out how to center
           */
-          // constraints: const BoxConstraints(minWidth: 700, maxWidth: 1000),
-          child: Center(
-            child: Row(
-              children: <Widget>[
-                smallScreen ? const SizedBox.shrink() : Expanded(
-                    child:
-                    NavigationRail(
-                        selectedIndex: _selectedIndex,
-                        labelType: NavigationRailLabelType.all,
-                        indicatorColor: colorGreen,
-                        onDestinationSelected: _navigationSelected,
-                        destinations: const <NavigationRailDestination> [
-                          NavigationRailDestination(
-                              icon: Icon(Icons.person_outline_outlined),
-                              selectedIcon: Icon(Icons.person,
-                                  color: Colors.white
-                              ),
-                              label: Text('Profile')
-                          ),
-                          NavigationRailDestination(
-                              icon: Icon(Icons.password_outlined),
-                              selectedIcon: Icon(Icons.password,
-                                  color: Colors.white
-                              ),
-                              label: Text('Password')
-                          ),
-                          NavigationRailDestination(
-                              icon: Icon(Icons.lock_outline),
-                              selectedIcon: Icon(Icons.lock,
-                                  color: Colors.white
-                              ),
-                              label: Text('Security')
+              // constraints: const BoxConstraints(minWidth: 700, maxWidth: 1000),
+              child: Center(
+                child: Row(
+                  children: <Widget>[
+                    smallScreen
+                        ? const SizedBox.shrink()
+                        : Expanded(
+                            child: NavigationRail(
+                                selectedIndex: _selectedIndex,
+                                labelType: NavigationRailLabelType.all,
+                                indicatorColor: colorGreen,
+                                onDestinationSelected: _navigationSelected,
+                                destinations: const <NavigationRailDestination>[
+                                NavigationRailDestination(
+                                    icon: Icon(Icons.person_outline_outlined),
+                                    selectedIcon:
+                                        Icon(Icons.person, color: Colors.white),
+                                    label: Text('Profile')),
+                                NavigationRailDestination(
+                                    icon: Icon(Icons.password_outlined),
+                                    selectedIcon: Icon(Icons.password,
+                                        color: Colors.white),
+                                    label: Text('Password')),
+                                NavigationRailDestination(
+                                    icon: Icon(Icons.lock_outline),
+                                    selectedIcon:
+                                        Icon(Icons.lock, color: Colors.white),
+                                    label: Text('Security'))
+                              ])),
+                    Expanded(
+                        flex: 8,
+                        child: Padding(
+                            padding: const EdgeInsets.all(20.0),
+                            child: screens[_selectedIndex]))
+                  ],
+                ),
+              )),
+          bottomNavigationBar: smallScreen
+              ? BottomNavigationBar(
+                  currentIndex: _selectedIndex,
+                  selectedItemColor: colorGreen,
+                  onTap: _navigationSelected,
+                  items: const <BottomNavigationBarItem>[
+                      BottomNavigationBarItem(
+                          icon: Icon(Icons.person_outline_outlined),
+                          label: 'Profile'),
+                      BottomNavigationBarItem(
+                          icon: Icon(Icons.password_outlined),
+                          label: 'Password'),
+                      BottomNavigationBarItem(
+                          icon: Icon(Icons.lock_outline), label: 'Security')
+                    ])
+              : Container(
+                  color: footerBlue,
+                  padding: const EdgeInsets.all(16.0),
+                  child: const Wrap(
+                        children: [
+                          Text(
+                            '© Copyright 2023 City of Los Angeles. '
+                                'All rights reserved. Disclaimer | Privacy Policy',
+                            style: TextStyle(color: Colors.white),
+                            textDirection: TextDirection.ltr,
                           )
-                        ]
-                    )
-                ),
-                Expanded(
-                    flex: 8,
-                    child: Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: screens[_selectedIndex]
-                    )
-                )
-              ],
-            ),
-          )
-        ),
-          bottomNavigationBar: smallScreen ?
-            BottomNavigationBar(
-              currentIndex: _selectedIndex,
-              selectedItemColor: colorGreen,
-              onTap: _navigationSelected,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                    icon: Icon(Icons.person_outline_outlined),
-                    label: 'Profile'
-                ),
-                BottomNavigationBarItem(
-                    icon: Icon(Icons.password_outlined),
-                    label: 'Password'
-                ),
-                BottomNavigationBarItem(
-                    icon: Icon(Icons.lock_outline),
-                    label: 'Security'
-                )
-              ]
-          ) : Container(
-               color: footerBlue,
-               padding: const EdgeInsets.all(16.0),
-               child: const Row(
-                 mainAxisAlignment: MainAxisAlignment.center,
-                 children: [
-                   Text('© Copyright 2023 City of Los Angeles. '
-                       'All rights reserved. Disclaimer | Privacy Policy',
-                     style: TextStyle(color: Colors.white)
-                   )
-                 ],
-              )
-            )
-      ),
+                        ],
+                      )
+                    )),
     );
   }
 }

--- a/lib/views/screens/password_screen.dart
+++ b/lib/views/screens/password_screen.dart
@@ -61,7 +61,7 @@ class _PasswordScreenState extends State<PasswordScreen> {
             )
           ],
         ),
-        const SizedBox(height: 10.0),
+        const SizedBox(height: 30.0),
         TextFormField(
           obscureText: !viewPassword,
           autocorrect: false,

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -19,12 +19,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
   late User providerUser;
   final GlobalKey<FormBuilderState> formKey = GlobalKey<FormBuilderState>();
 
-  late bool _isEditing;
-
   @override
   void initState() {
     super.initState();
-    _isEditing = false;
   }
 
   void updateUser() {
@@ -50,138 +47,136 @@ class _ProfileScreenState extends State<ProfileScreen> {
         autovalidateMode: AutovalidateMode.disabled,
         skipDisabled: true,
         child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            ElevatedButton(
-                              onPressed: () {
-                                if (_isEditing) {
-                                  updateUser();
-                                }
-                                setState(() {
-                                  _isEditing = !_isEditing;
-                                });
-                              },
-                              style: actionButtonStyle,
-                              child: Text(_isEditing ? 'Save' : 'Edit'),
-                            )
-                          ]
-                      ),
-                      const SizedBox(height: 10.0),
-                      TextFormField(
-                        enabled: false,
-                        decoration: const InputDecoration(
-                            labelText: 'Full Name',
-                            border: OutlineInputBorder()
-                        ),
-                        keyboardType: TextInputType.name,
-                        initialValue: providerUser.fullName,
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: false,
-                        decoration: const InputDecoration(
-                            labelText: 'Email',
-                            border: OutlineInputBorder()
-                        ),
-                        initialValue: providerUser.email,
-                        keyboardType: TextInputType.emailAddress,
-                        onChanged: (final val) {
-                          providerUser.email = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'First Name',
-                            border: OutlineInputBorder()
-                        ),
-                        initialValue: providerUser.firstName,
-                        keyboardType: TextInputType.name,
-                        onChanged: (final val) {
-                         providerUser.firstName = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'Last Name',
-                            border: OutlineInputBorder()
-                        ),
-                        initialValue: providerUser.lastName,
-                        keyboardType: TextInputType.name,
-                        onChanged: (final val) {
-                          providerUser.lastName = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'Zip',
-                            border: OutlineInputBorder()
-                        ),
-                        initialValue: providerUser.zip,
-                        onChanged: (final val) {
-                         providerUser.zip = val;
-                        },
-                        keyboardType: TextInputType.number,
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'Address',
-                            border: OutlineInputBorder()
-                        ),
-                        keyboardType: TextInputType.streetAddress,
-                        onChanged: (final val) {
-                          providerUser.address = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'City',
-                            border: OutlineInputBorder()
-                        ),
-                        keyboardType: TextInputType.streetAddress,
-                        onChanged: (final val) {
-                          providerUser.city = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'State',
-                            border: OutlineInputBorder()
-                        ),
-                        keyboardType: TextInputType.streetAddress,
-                        onChanged: (final val) {
-                          providerUser.state = val;
-                        },
-                      ),
-                      const SizedBox(height: 25.0),
-                      TextFormField(
-                        enabled: _isEditing ? true : false,
-                        decoration: const InputDecoration(
-                            labelText: 'Mobile',
-                            border: OutlineInputBorder()
-                        ),
-                        initialValue: providerUser.phone,
-                        onChanged: (final val) {
-                          providerUser.phone = val;
-                        },
-                      ),
-                    ],
-                  ),
-                )
+          child: Column(
+            children: [
+              Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        if (userProvider.isEditing) {
+                          updateUser();
+                        }
+                        userProvider.toggleEditing();
+                      },
+                      style: actionButtonStyle,
+                      child: Text(userProvider.isEditing ? 'Save' : 'Edit'),
+                    )
+                  ]
+              ),
+              const SizedBox(height: 10.0),
+              TextFormField(
+                enabled: false,
+                decoration: const InputDecoration(
+                    labelText: 'Full Name',
+                    border: OutlineInputBorder()
+                ),
+                keyboardType: TextInputType.name,
+                initialValue: providerUser.fullName,
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: false,
+                decoration: const InputDecoration(
+                    labelText: 'Email',
+                    border: OutlineInputBorder()
+                ),
+                initialValue: providerUser.email,
+                keyboardType: TextInputType.emailAddress,
+                onChanged: (final val) {
+                  providerUser.email = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'First Name',
+                    border: OutlineInputBorder()
+                ),
+                initialValue: providerUser.firstName,
+                keyboardType: TextInputType.name,
+                onChanged: (final val) {
+                 providerUser.firstName = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'Last Name',
+                    border: OutlineInputBorder()
+                ),
+                initialValue: providerUser.lastName,
+                keyboardType: TextInputType.name,
+                onChanged: (final val) {
+                  providerUser.lastName = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'Zip',
+                    border: OutlineInputBorder()
+                ),
+                initialValue: providerUser.zip,
+                onChanged: (final val) {
+                 providerUser.zip = val;
+                },
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'Address',
+                    border: OutlineInputBorder()
+                ),
+                keyboardType: TextInputType.streetAddress,
+                onChanged: (final val) {
+                  providerUser.address = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'City',
+                    border: OutlineInputBorder()
+                ),
+                keyboardType: TextInputType.streetAddress,
+                onChanged: (final val) {
+                  providerUser.city = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'State',
+                    border: OutlineInputBorder()
+                ),
+                keyboardType: TextInputType.streetAddress,
+                onChanged: (final val) {
+                  providerUser.state = val;
+                },
+              ),
+              const SizedBox(height: 25.0),
+              TextFormField(
+                enabled: userProvider.isEditing,
+                decoration: const InputDecoration(
+                    labelText: 'Mobile',
+                    border: OutlineInputBorder()
+                ),
+                initialValue: providerUser.phone,
+                onChanged: (final val) {
+                  providerUser.phone = val;
+                },
+              ),
+            ],
+          ),
+        )
 
     );
   }

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -29,7 +29,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
   @override
   Widget build(final BuildContext context) {
-
     final userProvider = context.watch<UserProvider>();
     if (userProvider.user == null) {
       userProvider.fetchUser();
@@ -38,144 +37,142 @@ class _ProfileScreenState extends State<ProfileScreen> {
       providerUser = userProvider.user!;
     }
 
-    return Form(
-        key: formKey,
-        onChanged: () {
-          formKey.currentState!.save();
-        },
-        autovalidateMode: AutovalidateMode.disabled,
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    ElevatedButton(
-                      onPressed: () {
-                        if (userProvider.isEditing) {
-                          updateUser();
-                        }
-                        userProvider.toggleEditing();
-                      },
-                      style: actionButtonStyle,
-                      child: Text(userProvider.isEditing ? 'Save' : 'Edit'),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+          ElevatedButton(
+            onPressed: () {
+              if (userProvider.isEditing) {
+                updateUser();
+              }
+              setState(() {
+                userProvider.toggleEditing();
+              });
+            },
+            style: actionButtonStyle,
+            child: Text(userProvider.isEditing ? 'Save' : 'Edit'),
+          )
+        ]),
+        const SizedBox(height: 20.0),
+        Expanded(
+            child: SingleChildScrollView(
+                child: Form(
+                    key: formKey,
+                    onChanged: () {
+                      formKey.currentState!.save();
+                    },
+                    autovalidateMode: AutovalidateMode.disabled,
+                    child: Column(
+                        children: [
+                          const SizedBox(height: 10.0),
+                          TextFormField(
+                            enabled: false,
+                            decoration: const InputDecoration(
+                                labelText: 'Full Name',
+                                border: OutlineInputBorder()),
+                            keyboardType: TextInputType.name,
+                            initialValue: providerUser.fullName,
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: false,
+                            decoration: const InputDecoration(
+                                labelText: 'Email',
+                                border: OutlineInputBorder()),
+                            initialValue: providerUser.email,
+                            keyboardType: TextInputType.emailAddress,
+                            onChanged: (final val) {
+                              providerUser.email = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'First Name',
+                                border: OutlineInputBorder()),
+                            initialValue: providerUser.firstName,
+                            keyboardType: TextInputType.name,
+                            onChanged: (final val) {
+                              providerUser.firstName = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'Last Name',
+                                border: OutlineInputBorder()),
+                            initialValue: providerUser.lastName,
+                            keyboardType: TextInputType.name,
+                            onChanged: (final val) {
+                              providerUser.lastName = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'Zip', border: OutlineInputBorder()),
+                            initialValue: providerUser.zip,
+                            onChanged: (final val) {
+                              providerUser.zip = val;
+                            },
+                            keyboardType: TextInputType.number,
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'Address',
+                                border: OutlineInputBorder()),
+                            keyboardType: TextInputType.streetAddress,
+                            initialValue: providerUser.address,
+                            onChanged: (final val) {
+                              providerUser.address = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'City',
+                                border: OutlineInputBorder()),
+                            keyboardType: TextInputType.streetAddress,
+                            initialValue: providerUser.city,
+                            onChanged: (final val) {
+                              providerUser.city = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'State',
+                                border: OutlineInputBorder()),
+                            keyboardType: TextInputType.streetAddress,
+                            onChanged: (final val) {
+                              providerUser.state = val;
+                            },
+                          ),
+                          const SizedBox(height: 25.0),
+                          TextFormField(
+                            enabled: userProvider.isEditing,
+                            decoration: const InputDecoration(
+                                labelText: 'Mobile',
+                                border: OutlineInputBorder()),
+                            initialValue: providerUser.phone,
+                            onChanged: (final val) {
+                              providerUser.phone = val;
+                            },
+                          ),
+                        ],
                     )
-                  ]
-              ),
-              const SizedBox(height: 10.0),
-              TextFormField(
-                enabled: false,
-                decoration: const InputDecoration(
-                    labelText: 'Full Name',
-                    border: OutlineInputBorder()
-                ),
-                keyboardType: TextInputType.name,
-                initialValue: providerUser.fullName,
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: false,
-                decoration: const InputDecoration(
-                    labelText: 'Email',
-                    border: OutlineInputBorder()
-                ),
-                initialValue: providerUser.email,
-                keyboardType: TextInputType.emailAddress,
-                onChanged: (final val) {
-                  providerUser.email = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'First Name',
-                    border: OutlineInputBorder()
-                ),
-                initialValue: providerUser.firstName,
-                keyboardType: TextInputType.name,
-                onChanged: (final val) {
-                 providerUser.firstName = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'Last Name',
-                    border: OutlineInputBorder()
-                ),
-                initialValue: providerUser.lastName,
-                keyboardType: TextInputType.name,
-                onChanged: (final val) {
-                  providerUser.lastName = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'Zip',
-                    border: OutlineInputBorder()
-                ),
-                initialValue: providerUser.zip,
-                onChanged: (final val) {
-                 providerUser.zip = val;
-                },
-                keyboardType: TextInputType.number,
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'Address',
-                    border: OutlineInputBorder()
-                ),
-                keyboardType: TextInputType.streetAddress,
-                onChanged: (final val) {
-                  providerUser.address = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'City',
-                    border: OutlineInputBorder()
-                ),
-                keyboardType: TextInputType.streetAddress,
-                onChanged: (final val) {
-                  providerUser.city = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'State',
-                    border: OutlineInputBorder()
-                ),
-                keyboardType: TextInputType.streetAddress,
-                onChanged: (final val) {
-                  providerUser.state = val;
-                },
-              ),
-              const SizedBox(height: 25.0),
-              TextFormField(
-                enabled: userProvider.isEditing,
-                decoration: const InputDecoration(
-                    labelText: 'Mobile',
-                    border: OutlineInputBorder()
-                ),
-                initialValue: providerUser.phone,
-                onChanged: (final val) {
-                  providerUser.phone = val;
-                },
-              ),
-            ],
-          ),
+                )
+            )
         )
-
+      ],
     );
   }
 }

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -1,6 +1,5 @@
 import 'package:angeleno_project/controllers/user_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:provider/provider.dart';
 
 import '../../controllers/api_implementation.dart';
@@ -17,7 +16,7 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen> {
   UserApi userApi = UserApi();
   late User providerUser;
-  final GlobalKey<FormBuilderState> formKey = GlobalKey<FormBuilderState>();
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
@@ -39,13 +38,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
       providerUser = userProvider.user!;
     }
 
-    return FormBuilder(
+    return Form(
         key: formKey,
         onChanged: () {
           formKey.currentState!.save();
         },
         autovalidateMode: AutovalidateMode.disabled,
-        skipDisabled: true,
         child: SingleChildScrollView(
           child: Column(
             children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,11 +34,12 @@ dependencies:
   flutter_svg: ^2.0.7
   url_launcher: ^6.1.12
   http: ^1.1.0
-  flutter_form_builder: ^9.1.0
   provider: ^6.0.5
 
 dev_dependencies:
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,8 +39,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  integration_test:
-    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,37 +5,27 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:angeleno_project/controllers/user_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:angeleno_project/main.dart';
-import 'package:integration_test/integration_test.dart';
-import 'package:provider/provider.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  // ignore: lines_longer_than_80_chars
+  testWidgets('Counter increments smoke test', (final WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MyApp());
 
-  testWidgets('Loads and switches screens', (final WidgetTester tester) async {
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
 
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (final _) => UserProvider())
-        ],
-        child: const MyApp()
-      )
-    );
-
-    await tester.pump(const Duration(seconds: 5));
-
-    expect(find.text('Full Name'), findsOneWidget);
-    expect(find.text('Current Password'), findsNothing);
-
-    await tester.tap(find.byIcon(Icons.password_outlined));
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
 
-    expect(find.text('Full Name'), findsNothing);
-    expect(find.text('Current Password'), findsOneWidget);
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,27 +5,37 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:angeleno_project/controllers/user_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:angeleno_project/main.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:provider/provider.dart';
 
 void main() {
-  // ignore: lines_longer_than_80_chars
-  testWidgets('Counter increments smoke test', (final WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  testWidgets('Loads and switches screens', (final WidgetTester tester) async {
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (final _) => UserProvider())
+        ],
+        child: const MyApp()
+      )
+    );
+
+    await tester.pump(const Duration(seconds: 5));
+
+    expect(find.text('Full Name'), findsOneWidget);
+    expect(find.text('Current Password'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.password_outlined));
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Full Name'), findsNothing);
+    expect(find.text('Current Password'), findsOneWidget);
   });
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the


### PR DESCRIPTION
### What does this PR do?
- Moves editing state to provider.
- Replaces third party Form dependency for first party usage.
- Also threw in the `lang` attribute to the `html` tag because it kept throwing an error in some scans I've been running locally.
![Screenshot 2023-08-31 131909](https://github.com/CityOfLosAngeles/angeleno-my-account-flutter/assets/6743989/050adb9a-0a95-408d-94f4-2e905649419e)
- Added Dialog to let user know when they're navigating away from their profile page with unsaved changes.
<img width="518" alt="Screenshot 2023-09-11 121752" src="https://github.com/CityOfLosAngeles/angeleno-my-account-flutter/assets/6743989/1453b2b4-6614-4b78-a83a-52c78a6703e2">


### Which issue(s) is/are related to this PR?
Closes https://github.com/CityOfLosAngeles/angeleno-my-account-flutter/issues/28
Closes https://github.com/CityOfLosAngeles/angeleno-my-account-flutter/issues/32