### PR TITLE
Patch Live Deployment

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,7 +3,11 @@
 # Flutter and .env config was not auto-generated
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'lib/**'
+      - 'web/**'
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "target": "angeleno-my-account-dev-402917",
     "public": "build/web",
     "ignore": [
       "firebase.json",


### PR DESCRIPTION
### What does this PR do?
Continuation of #14 

Made an update so that the live deployment goes to a specific "target" but that errored out because it wasn't found in 'firebase.json' so I've added it.

Also added an update so that github actions only deploy preview channels when necessary, i.e. when changes are made to the source code, and not triggered when changes to static files (mostly *.md files) are made.