### PR TITLE
Fix Auth0 Audience with Custom Domain Issue

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - development
+      - sandbox
+      - production
 jobs:
   build_and_deploy:
-    environment: development
+    environment: ${{git.ref}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false }}'
     runs-on: ubuntu-latest
-    environment: development
+    environment: ${{git.ref}}
     steps:
       - uses: actions/checkout@v4
        # https://github.com/marketplace/actions/flutter-action

--- a/functions/auth0/utils/auth0.js
+++ b/functions/auth0/utils/auth0.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 import {
   auth0Domain,
+  auth0NonCustomDomain,
   auth0ClientId,
   auth0ClientSecret
 } from './constants.js';
@@ -28,7 +29,7 @@ export const getAccessToken = async () => {
     'grant_type': 'client_credentials',
     'client_id': auth0ClientId,
     'client_secret': auth0ClientSecret,
-    'audience': `https://${auth0Domain}/api/v2/`
+    'audience': `https://${auth0NonCustomDomain}/api/v2/`
   };
 
   try {
@@ -61,7 +62,7 @@ export const authorizeUser = async (email, password, audience = '/api/v2/') => {
         'password': password,
         'client_id': auth0ClientId,
         'client_secret': auth0ClientSecret,
-        'audience': `https://${auth0Domain}${audience}`,
+        'audience': `https://${auth0NonCustomDomain}${audience}`,
         'scope': audience === '/api/v2/' ? 'openid' : ''
       })
     };

--- a/functions/auth0/utils/constants.js
+++ b/functions/auth0/utils/constants.js
@@ -1,6 +1,7 @@
 export const {
   auth0ClientId,
   auth0ClientSecret,
+  auth0NonCustomDomain,
   auth0Domain
 } = process.env;
 

--- a/lib/views/screens/advanced_security_screen.dart
+++ b/lib/views/screens/advanced_security_screen.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:angeleno_project/controllers/auth0_user_api_implementation.dart';
 import 'package:angeleno_project/utils/constants.dart';
 import 'package:angeleno_project/views/dialogs/mobile.dart';
-import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:flutter/material.dart';
 
 

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:angeleno_project/controllers/user_provider.dart';
 import 'package:angeleno_project/utils/constants.dart';
-import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';


### PR DESCRIPTION
### What does this PR do?
Found out that requests using the Audience parameter with our custom domain were failing. This update makes it so that we use the original domain for the audience parameter.

Additional changes:

- Updated github actions to use agnostic environment variables... might not work as expected for the PR action, but will keep an eye one it
- Remove unused imports.
