### PR TITLE
Add z-index to city navbar

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -32,6 +32,15 @@
   <script src="assets/packages/libphonenumber_plugin/js/libphonenumber.js"></script>
   <script src="assets/packages/libphonenumber_plugin/js/stringbuffer.js"></script>
 
+  <style>
+    [id^="global_navbar_la_"] {
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        width: 100%;
+      }
+  </style>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
This pull request includes a small change to the `web/index.html` file. It adds a new inline CSS style to position elements with IDs starting with `global_navbar_la_` at the top of the page with a high z-index for proper layering.