### PR TITLE
Remove duplicate code & show loading indicator

### DIFF
--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -200,12 +200,6 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(final BuildContext context) {
     var userEmail = '';
-    overlayProvider = Provider.of<OverlayProvider>(context);
-    userProvider = context.watch<UserProvider>();
-    if (userProvider.user != null) {
-      user = userProvider.user!;
-      userEmail = user.email;
-    }
 
     overlayProvider = context.watch<OverlayProvider>();
     userProvider = context.watch<UserProvider>();
@@ -214,6 +208,10 @@ class _MyHomePageState extends State<MyHomePage> {
     if (userProvider.user != null) {
       user = userProvider.user!;
       userEmail = user.email;
+    } else {
+      return const Center(
+        child: LinearProgressIndicator()
+      );
     }
 
     return Listener(


### PR DESCRIPTION
### What does this PR do?
Patch for #203 

Removes duplicate code and displays a loading indicator when accessing a route but no user credentials are found.