### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/functions/auth0/index.js
+++ b/functions/auth0/index.js
@@ -18,11 +18,22 @@ import {
   requestMFAToken
 } from './api/auth0.js';
 
+import rateLimit from 'express-rate-limit';
+
 admin.initializeApp();
 setGlobalOptions({
   region: 'us-west1'
 })
 const app = express();
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.use(limiter);
 
 const client = jwksClient({
   jwksUri: `https://${auth0Domain}/.well-known/jwks.json`

--- a/functions/auth0/package.json
+++ b/functions/auth0/package.json
@@ -20,7 +20,8 @@
     "express": "^4.22.1",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^5.0.1",
-    "jsonwebtoken": "9.0.2"
+    "jsonwebtoken": "9.0.2",
+    "express-rate-limit": "^8.3.1"
   },
   "devDependencies": {
     "eslint": "^8.15.0",


### PR DESCRIPTION
Potential fix for [https://github.com/CityOfLosAngeles/angeleno-account-my-account/security/code-scanning/24](https://github.com/CityOfLosAngeles/angeleno-account-my-account/security/code-scanning/24)

In general, the problem is fixed by introducing a rate-limiting middleware into the Express app so that the number of requests per client (for example, per IP) within a time window is bounded. This middleware should be applied as early as possible in the middleware chain, before the authorization logic that verifies JWTs, so abusive traffic is blocked before triggering heavy computation or network activity.

For this specific code, the best minimally invasive fix is:
- Import a well-known Express rate-limiting library such as `express-rate-limit`.
- Configure a limiter instance with reasonable defaults (e.g., a number of requests per 15‑minute window) that match or approximate the security policy; since we must not change functional behavior beyond security hardening and we do not see other constraints, we choose a conservative yet realistic limit (e.g., 100 requests per 15 minutes per IP).
- Apply the limiter globally to the `app` before the JWT authorization middleware on line 38. This ensures all routes benefit from rate limiting and that JWT verification is shielded from floods.

Concretely:
- In `functions/auth0/index.js`, add `import rateLimit from 'express-rate-limit';` near the other imports.
- After `const app = express();` (line 25), define a limiter, e.g.:

  ```js
  const limiter = rateLimit({
    windowMs: 15 * 60 * 1000,
    max: 100,
    standardHeaders: true,
    legacyHeaders: false,
  });
  ```

- Add `app.use(limiter);` immediately after this declaration and before the JWT auth middleware at line 38.
No other existing routes or logic need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
